### PR TITLE
A git object can also be of zero size.

### DIFF
--- a/lib/Git/PurePerl/Loose.pm
+++ b/lib/Git/PurePerl/Loose.pm
@@ -22,7 +22,7 @@ sub get_object {
 
     my $compressed = $filename->slurp( iomode => '<:raw' );
     my $data       = uncompress($compressed);
-    my ( $kind, $size, $content ) = $data =~ /^(\w+) (\d+)\0(.+)$/s;
+    my ( $kind, $size, $content ) = $data =~ /^(\w+) (\d+)\0(.*)$/s;
     return ( $kind, $size, $content );
 }
 


### PR DESCRIPTION
This fixes rare occurences of all_objects returning an undefined object.
