### PR TITLE
Packed indexes need to be read raw.

### DIFF
--- a/lib/Git/PurePerl/PackIndex.pm
+++ b/lib/Git/PurePerl/PackIndex.pm
@@ -28,6 +28,7 @@ sub BUILD {
     my $filename = $self->filename;
 
     my $fh = IO::File->new($filename) || confess($!);
+    $fh->binmode;
     $self->fh($fh);
 
     my @offsets = (0);


### PR DESCRIPTION
This fixes index offset reading errors on windows, caused by Perl's auto-conversion of \r\n.
