### PR TITLE
fix for the retrieval of ref sha1s

### DIFF
--- a/lib/Git/PurePerl.pm
+++ b/lib/Git/PurePerl.pm
@@ -198,11 +198,20 @@ sub ref_sha1 {
 
     my $packed_refs = file( $self->gitdir, 'packed-refs' );
     if ( -f $packed_refs ) {
+        my $last_name;
+        my $last_sha1;
         foreach my $line ( $packed_refs->slurp( chomp => 1 ) ) {
             next if $line =~ /^#/;
             my ( $sha1, my $name ) = split ' ', $line;
-            return _ensure_sha1_is_sha1( $self, $sha1 ) if $name eq $wantref;
+            $sha1 =~ s/^\^//;
+            $name ||= $last_name;
+
+            return _ensure_sha1_is_sha1( $self, $last_sha1 ) if $last_name and $last_name eq $wantref and $name ne $wantref;
+
+            $last_name = $name;
+            $last_sha1 = $sha1;
         }
+        return _ensure_sha1_is_sha1( $self, $last_sha1 ) if $last_name eq $wantref;
     }
     return undef;
 }


### PR DESCRIPTION
Due to tag refs possibly being able to have two sha1s (one for the commit, one for the tag object), some changes were necessary to ensure that ref retrieval functions always return the commit.

The tag object can be retrieved, if necessary, via all_objects still.
