### PR TITLE
Update repository URL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ author 'Leon Brocard <acme@astray.com>';
 abstract 'A Pure Perl interface to Git repositories';
 license 'perl';
 
-resources repository => 'git://github.com/bobtfish/git-pureperl.git';
+resources repository => 'git://github.com/broquaint/git-pureperl.git';
 
 requires        'Archive::Extract'           => '0';
 requires        'Compress::Raw::Zlib'        => '0';

--- a/lib/Git/PurePerl.pm
+++ b/lib/Git/PurePerl.pm
@@ -531,7 +531,7 @@ It was mostly based on Grit L<http://grit.rubyforge.org/>.
 
 =head1 MAINTAINANCE
 
-This module is maintained in git at L<http://github.com/bobtfish/git-pureperl/>.
+This module is maintained in git at L<http://github.com/broquaint/git-pureperl/>.
 
 Patches are welcome, please come speak to one of the L<Gitalist> team
 on C<< #gitalist >>.


### PR DESCRIPTION
Building on broquaint/git-pureperl#7 this updates the two outdated repository links, which would fix the outdated link on MetaCPAN.

This pull-request is part of the [2015 CPAN PR Challenge](http://blogs.perl.org/users/neilb/2014/12/take-the-2015-cpan-pull-request-challenge.html)