### PR TITLE
Fix test failures on CPAN Testers

### DIFF
--- a/t/protocol_gpp.t
+++ b/t/protocol_gpp.t
@@ -6,6 +6,13 @@ use IO::File;
 use Path::Class;
 use Test::More;
 
+my $socket = IO::Socket::INET->new("www.github.com:80");
+if ($socket) {
+    close ($socket);
+} else {
+    plan skip_all => 'No Internet connection available';
+}
+
 my $directory = 'test-protocol';
 dir($directory)->rmtree;
 


### PR DESCRIPTION
This should fix most of the failures shown on CPAN Testers which are caused by testing environments which
don't provide internet access while the tests are run.

The idea for the fix was taken from FreeBSD
https://svnweb.freebsd.org/ports/head/devel/p5-Git-PurePerl/?pathrev=375886

This pull-request is part of the [2015 CPAN PR Challenge](http://blogs.perl.org/users/neilb/2014/12/take-the-2015-cpan-pull-request-challenge.html)