### PR TITLE
Add support for creating merge commits to Git::PurePerl::Object::Commit

### DIFF
--- a/lib/Git/PurePerl/NewObject/Commit.pm
+++ b/lib/Git/PurePerl/NewObject/Commit.pm
@@ -10,7 +10,7 @@ extends 'Git::PurePerl::NewObject';
 has 'kind' =>
     ( is => 'ro', isa => 'ObjectKind', required => 1, default => 'commit' );
 has 'tree'   => ( is => 'rw', isa => 'Str',                  required => 1 );
-has 'parent' => ( is => 'rw', isa => 'Str',                  required => 0 );
+has 'parent' => ( is => 'rw', isa => 'Str|ArrayRef[Str]',    required => 0 );
 has 'author' => ( is => 'rw', isa => 'Git::PurePerl::Actor', required => 1 );
 has 'authored_time' => ( is => 'rw', isa => 'DateTime', required => 1 );
 has 'committer' =>
@@ -23,7 +23,14 @@ sub _build_content {
     my $content;
 
     $content .= 'tree ' . $self->tree . "\n";
-    $content .= 'parent ' . $self->parent . "\n" if $self->parent;
+    if ( my $parent = $self->parent ) {
+        if ( ref $parent ) {
+            $content .= "parent $_\n" for @$parent;
+        }
+        else {
+            $content .= "parent $parent\n";
+        }
+    }
     $content
         .= "author "
         . $self->author->name . ' <'


### PR DESCRIPTION
Git::PurePerl::Object::Commit 'parent' was a simple Str, and content
was built with a single 'parent' line. This meant it was impossible
to create merge commits (commits with multiple parents).

This patch changes the 'isa' constraint for 'parent', making it
possible to pass a reference to an array of parents.

_build_content is modified to behave correctly for all value types.